### PR TITLE
RA-395: changing scm to release from bamboo; 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,10 +11,9 @@
 	<url>http://openmrs.org</url>
 	
 	<scm>
-		<connection>scm:git:https://github.com/openmrs/openmrs-module-reporting/</connection>
-		<developerConnection>scm:git:https://github.com/openmrs/openmrs-module-reporting/</developerConnection>
+		<connection>scm:git:git@github.com:openmrs/openmrs-module-reporting.git</connection>
+		<developerConnection>scm:git:git@github.com:openmrs/openmrs-module-reporting.git</developerConnection>
 		<url>https://github.com/openmrs/openmrs-module-reporting/</url>
-	  <tag>0.9.2</tag>
   </scm>
 	
 	<distributionManagement>
@@ -371,6 +370,11 @@
 						<autoVersionSubmodules>true</autoVersionSubmodules>
 						<tagNameFormat>@{project.version}</tagNameFormat>
 					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>2.9.1</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
fixing the version of javadoc due to a regression on 2.10 (https://groups.google.com/a/openmrs.org/forum/#!msg/dev/1M4bep9-Brk/9sW0y1gMj1sJ). As this module was failing, I made it fixed. 
