### PR TITLE
REPORT-724: add aware_of_module dependency for reportingcompatibility's ...

### DIFF
--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -23,6 +23,10 @@
 	   	<require_module version="${calculationVersion}">org.openmrs.calculation</require_module>
 	</require_modules>
 
+	<aware_of_modules>
+    	<aware_of_module version="1.5.9-SNAPSHOT">org.openmrs.module.reportingcompatibility</aware_of_module>
+	</aware_of_modules>
+
 	<!-- Extensions -->
 	<extension>
 		<point>org.openmrs.admin.list</point>


### PR DESCRIPTION
...AbstractReportObject, required to run core 1.12 after recent classloader changes

Tactical fix to get things running under 1.12 again. 