### PR TITLE
Change the dev@openmrs.org to OpenMRS Talk

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Reporting Module was designed to provide a feature-rich and user-friendly we
 
 Download
 ========
-We encourage all OpenMRS users and developers to download the reporting module, use it frequently, create new tickets for bug fixes and feature requests, and provide feedback to dev@openmrs.org.
+We encourage all OpenMRS users and developers to download the reporting module, use it frequently, create new tickets for bug fixes and feature requests, and provide feedback on [OpenMRS Talk](https://talk.openmrs.org/c/developers).
 
 
 Requirements


### PR DESCRIPTION
Since the developers list has been discontinued, this should be changed. Caught this while reviewing a GCI PR improving the readability of the README

Did not want to commit directly. @mseaton?