### PR TITLE
REPORT-761 - Automatically load definitions at startup (initial support for CohortDefinitions)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ omod/.settings/*
 omod/target/*
 test-1.9/target/*
 /.settings
+*.DS_Store

--- a/api-tests/src/test/java/org/openmrs/module/reporting/cohort/definition/evaluator/DefinitionLibraryCohortDefinitionEvaluatorTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/reporting/cohort/definition/evaluator/DefinitionLibraryCohortDefinitionEvaluatorTest.java
@@ -55,6 +55,7 @@ public class DefinitionLibraryCohortDefinitionEvaluatorTest extends BaseModuleCo
     @Before
     public void setup() throws Exception {
         executeDataSet(XML_DATASET_PATH + new TestUtil().getTestDatasetFilename(XML_REPORT_TEST_DATASET));
+        libraries.initLibraries();
     }
 
     @Test

--- a/api-tests/src/test/java/org/openmrs/module/reporting/data/patient/evaluator/DefinitionLibraryPatientDataEvaluatorTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/reporting/data/patient/evaluator/DefinitionLibraryPatientDataEvaluatorTest.java
@@ -24,6 +24,7 @@ import org.openmrs.module.reporting.data.patient.EvaluatedPatientData;
 import org.openmrs.module.reporting.data.patient.definition.DefinitionLibraryPatientDataDefinition;
 import org.openmrs.module.reporting.data.patient.library.BuiltInPatientDataLibrary;
 import org.openmrs.module.reporting.data.patient.service.PatientDataService;
+import org.openmrs.module.reporting.definition.library.AllDefinitionLibraries;
 import org.openmrs.module.reporting.evaluation.EvaluationContext;
 import org.openmrs.test.BaseModuleContextSensitiveTest;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,9 @@ import static org.junit.Assert.assertThat;
 public class DefinitionLibraryPatientDataEvaluatorTest extends BaseModuleContextSensitiveTest {
 
     @Autowired
+    private AllDefinitionLibraries definitionLibraries;
+
+    @Autowired
     private PatientDataService service;
 
     protected static final String XML_DATASET_PATH = "org/openmrs/module/reporting/include/";
@@ -47,6 +51,7 @@ public class DefinitionLibraryPatientDataEvaluatorTest extends BaseModuleContext
     @Before
     public void setup() throws Exception {
         executeDataSet(XML_DATASET_PATH + new TestUtil().getTestDatasetFilename(XML_REPORT_TEST_DATASET));
+        definitionLibraries.initLibraries();
     }
 
     @Test

--- a/api-tests/src/test/java/org/openmrs/module/reporting/data/patient/service/PatientDataServiceImplTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/reporting/data/patient/service/PatientDataServiceImplTest.java
@@ -146,6 +146,7 @@ public class PatientDataServiceImplTest extends BaseModuleContextSensitiveTest {
         PersonAttributeType testAttributeType = setUpTestPatientPersonAttribute(2, 7);
         TestPatientCohortDefinitionLibrary library = new TestPatientCohortDefinitionLibrary();
 
+	    libraries.initLibraries();
         libraries.addLibrary(library);
         TestUtil.updateGlobalProperty(ReportingConstants.GLOBAL_PROPERTY_TEST_PATIENTS_COHORT_DEFINITION,
                 "library:patientDataServiceImplTest.testPatients");

--- a/api-tests/src/test/java/org/openmrs/module/reporting/definition/library/AllDefinitionLibrariesComponentTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/reporting/definition/library/AllDefinitionLibrariesComponentTest.java
@@ -1,5 +1,6 @@
 package org.openmrs.module.reporting.definition.library;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
 import org.openmrs.module.reporting.data.encounter.definition.EncounterDataDefinition;
@@ -19,6 +20,11 @@ public class AllDefinitionLibrariesComponentTest extends BaseModuleContextSensit
 
     @Autowired
     AllDefinitionLibraries libraries;
+
+    @Before
+    public void setUp() throws Exception {
+        libraries.initLibraries();
+    }
 
     @Test
     public void testSetup() throws Exception {

--- a/api/src/main/java/org/openmrs/module/reporting/ReportingModuleActivator.java
+++ b/api/src/main/java/org/openmrs/module/reporting/ReportingModuleActivator.java
@@ -20,6 +20,7 @@ import org.openmrs.module.BaseModuleActivator;
 import org.openmrs.module.DaemonToken;
 import org.openmrs.module.DaemonTokenAware;
 import org.openmrs.module.reporting.common.MessageUtil;
+import org.openmrs.module.reporting.definition.library.AllDefinitionLibraries;
 import org.openmrs.module.reporting.report.task.ReportingTimerTask;
 import org.openmrs.module.reporting.report.task.RunQueuedReportsTask;
 
@@ -39,7 +40,10 @@ public class ReportingModuleActivator extends BaseModuleActivator implements Dae
     @Override
 	public void started() {
 		ReportingTimerTask.setEnabled(true);
-		log.info("Reporting Module Started...");
+	    for (AllDefinitionLibraries adl : Context.getRegisteredComponents(AllDefinitionLibraries.class)) {
+		    adl.initLibraries();
+	    }
+	    log.info("Reporting Module Started...");
 	}
 
 	@Override

--- a/api/src/main/java/org/openmrs/module/reporting/definition/library/AllDefinitionLibraries.java
+++ b/api/src/main/java/org/openmrs/module/reporting/definition/library/AllDefinitionLibraries.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -31,8 +32,41 @@ import java.util.Set;
 @Repository
 public class AllDefinitionLibraries {
 
+	/**
+     * Modules can define beans that implement DefinitionLibrary
+     */
     @Autowired(required = false)
+    private List<DefinitionLibrary<?>> libraryBeans;
+
+	/**
+     * Modules can define beans that implement DefinitionLibraryFactory
+     */
+    @Autowired(required = false)
+    private List<DefinitionLibraryFactory> libraryFactories;
+
+	/**
+     * Will be populated by {@link }initLibraries()}
+     */
     private List<DefinitionLibrary<?>> libraries;
+
+	/**
+     * This should be called after the Spring context is initialized and libraryBeans and libraryFactories have been
+     * autowired (e.g. from this module's activator)
+     */
+    public void initLibraries() {
+        libraries = new ArrayList<DefinitionLibrary<?>>();
+        if (libraryBeans != null) {
+            libraries.addAll(libraryBeans);
+        }
+        if (libraryFactories != null) {
+            for (DefinitionLibraryFactory factory : libraryFactories) {
+                Collection<DefinitionLibrary<?>> fromFactory = factory.getDefinitionLibraries();
+                if (fromFactory != null) {
+                    libraries.addAll(fromFactory);
+                }
+            }
+        }
+    }
 
     public List<LibraryDefinitionSummary> getDefinitionSummaries(Class<? extends Definition> returnType) {
         if (returnType == null) {

--- a/api/src/main/java/org/openmrs/module/reporting/definition/library/BaseImplementerConfiguredDefinitionLibrary.java
+++ b/api/src/main/java/org/openmrs/module/reporting/definition/library/BaseImplementerConfiguredDefinitionLibrary.java
@@ -1,0 +1,125 @@
+package org.openmrs.module.reporting.definition.library;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.api.SerializationService;
+import org.openmrs.module.reporting.evaluation.Definition;
+import org.openmrs.module.reporting.serializer.ReportingSerializer;
+import org.openmrs.serialization.OpenmrsSerializer;
+import org.openmrs.serialization.SerializationException;
+import org.openmrs.util.OpenmrsUtil;
+
+/**
+ * Supports loading files with the extentions:
+ * <ul>
+ *     <li>.reportingserializerxml ... will be deserialized with {@link ReportingSerializer}</li>
+ *     <li>.sql ... will producethe appropriate SqlXyzDefinition class</li>
+ * </ul>
+ * @see {@link ImplementerConfiguredDefinitionLibraryFactory}
+ * @param <T>
+ */
+public abstract class BaseImplementerConfiguredDefinitionLibrary<T extends Definition> implements DefinitionLibrary<T> {
+
+	protected static final Log log = LogFactory.getLog(BaseImplementerConfiguredDefinitionLibrary.class);
+
+	private Class<? super T> definitionClass;
+	private String libraryNameSuffix;
+	private File directory;
+
+	private Map<String, T> definitions = new LinkedHashMap<String, T>();
+	private List<LibraryDefinitionSummary> summaries = new ArrayList<LibraryDefinitionSummary>();
+
+	/**
+	 * @param definitionClass the class that all definitions should be a subclass of
+	 * @param libraryNameSuffix what name to give this library (and also subdirectory where definitions are)
+	 */
+	protected BaseImplementerConfiguredDefinitionLibrary(Class<? super T> definitionClass, String libraryNameSuffix,
+	                                                     SerializationService serializationService, File directory) {
+		this.definitionClass = definitionClass;
+		this.libraryNameSuffix = libraryNameSuffix;
+		this.directory = directory;
+
+		OpenmrsSerializer serializer = serializationService.getSerializer(ReportingSerializer.class);
+		for (File file : directory.listFiles()) {
+			String filename = file.getName();
+			String definitionName = filename.substring(0, filename.lastIndexOf('.'));
+			String key = getKeyPrefix() + definitionName;
+			try {
+				log.info("Loading " + file.getAbsolutePath());
+				Definition definition = null;
+				if (filename.endsWith(".reportingserializerxml")) {
+					try {
+						definition = serializer.deserialize(OpenmrsUtil.getFileAsString(file), Definition.class);
+					}
+					catch (SerializationException ex) {
+						log.warn("Invalid serialized definition at " + libraryNameSuffix + " in " + file.getAbsolutePath(), ex);
+					}
+				}
+				else if (filename.endsWith(".sql")) {
+					String sql = OpenmrsUtil.getFileAsString(file);
+					definition = sqlDefinition(sql);
+				}
+				else {
+					log.warn("Don't know how to handle " + file.getAbsolutePath() + " based on file extension");
+				}
+				if (definition != null) {
+					if (definition.getName() == null) {
+						definition.setName(key + ".name");
+					}
+					if (definition.getDescription() == null) {
+						definition.setDescription(key + ".description");
+					}
+					definitions.put(key, (T) definition);
+					summaries.add(summaryFor(key, definition));
+				}
+			}
+			catch (IOException ex) {
+				log.warn("Error reading " + file.getAbsolutePath(), ex);
+			}
+		}
+	}
+
+	@Override
+	public Class<? super T> getDefinitionType() {
+		return definitionClass;
+	}
+
+	@Override
+	public String getKeyPrefix() {
+		return "configuration.definitionlibrary." + libraryNameSuffix + ".";
+	}
+
+	@Override
+	public T getDefinition(String uuid) {
+		return definitions.get(uuid);
+	}
+
+	@Override
+	public List<LibraryDefinitionSummary> getDefinitionSummaries() {
+		return summaries;
+	}
+
+	public boolean hasAnyDefinitions() {
+		return definitions != null && definitions.size() > 0;
+	}
+
+	protected abstract T sqlDefinition(String sql);
+
+	private LibraryDefinitionSummary summaryFor(String key, Definition definition) {
+		LibraryDefinitionSummary summary = new LibraryDefinitionSummary();
+		summary.setKey(key);
+		summary.setType(definition.getClass().getName());
+		summary.setName(definition.getName());
+		summary.setDescription(definition.getDescription());
+		summary.setParameters(definition.getParameters());
+		return summary;
+	}
+
+}

--- a/api/src/main/java/org/openmrs/module/reporting/definition/library/DefinitionLibraryFactory.java
+++ b/api/src/main/java/org/openmrs/module/reporting/definition/library/DefinitionLibraryFactory.java
@@ -1,0 +1,16 @@
+package org.openmrs.module.reporting.definition.library;
+
+import java.util.Collection;
+
+/**
+ * Implementing a bean of this interface allows you to dynamically create zero or more {@link DefinitionLibrary}s.
+ */
+public interface DefinitionLibraryFactory {
+
+	/**
+	 * An implementation of this interface can count on this method being invoked once by the Reporting module's activator.
+	 * @return 0 or more definition libraries you want to register
+	 */
+	Collection<DefinitionLibrary<?>> getDefinitionLibraries();
+	
+}

--- a/api/src/main/java/org/openmrs/module/reporting/definition/library/ImplementerConfiguredCohortDefinitionLibrary.java
+++ b/api/src/main/java/org/openmrs/module/reporting/definition/library/ImplementerConfiguredCohortDefinitionLibrary.java
@@ -1,0 +1,20 @@
+package org.openmrs.module.reporting.definition.library;
+
+import java.io.File;
+
+import org.openmrs.api.SerializationService;
+import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
+import org.openmrs.module.reporting.cohort.definition.SqlCohortDefinition;
+
+public class ImplementerConfiguredCohortDefinitionLibrary extends BaseImplementerConfiguredDefinitionLibrary<CohortDefinition> {
+
+	public ImplementerConfiguredCohortDefinitionLibrary(SerializationService serializationService, File directory) {
+		super(CohortDefinition.class, "cohort", serializationService, directory);
+	}
+
+	@Override
+	protected CohortDefinition sqlDefinition(String sql) {
+		return new SqlCohortDefinition(sql);
+	}
+
+}

--- a/api/src/main/java/org/openmrs/module/reporting/definition/library/ImplementerConfiguredDefinitionLibraryFactory.java
+++ b/api/src/main/java/org/openmrs/module/reporting/definition/library/ImplementerConfiguredDefinitionLibraryFactory.java
@@ -1,0 +1,47 @@
+package org.openmrs.module.reporting.definition.library;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.openmrs.api.SerializationService;
+import org.openmrs.util.OpenmrsUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * At module startup, this factory will register definition libraries based on <em>files</em> that the implementer has
+ * configured on the file system.
+ *
+ * For example if the implementer puts a "females.sql" file at "$APPDATA/configuration/reporting/definitionlibraries/cohort",
+ * then there will be a SqlCohortDefinition available from {@link AllDefinitionLibraries} with the key
+ * "configuration.definitionlibrary.cohort.females".
+ *
+ * See {@link BaseImplementerConfiguredDefinitionLibrary} and all its concrete subclasses.
+ */
+@Component
+public class ImplementerConfiguredDefinitionLibraryFactory implements DefinitionLibraryFactory {
+
+	public static final String DIRECTORY = File.separator + "configuration" + File.separator + "reporting" + File.separator + "definitionlibraries" + File.separator;
+
+	@Autowired
+	private SerializationService serializationService;
+
+	@Override
+	public Collection<DefinitionLibrary<?>> getDefinitionLibraries() {
+		String appData = OpenmrsUtil.getApplicationDataDirectory();
+		List<DefinitionLibrary<?>> list = new ArrayList<DefinitionLibrary<?>>();
+		maybeAdd(list, new ImplementerConfiguredCohortDefinitionLibrary(serializationService,
+				new File(appData + DIRECTORY + "cohort")));
+		return list;
+	}
+
+	private void maybeAdd(List<DefinitionLibrary<?>> list,
+	                      BaseImplementerConfiguredDefinitionLibrary<?> library) {
+		if (library.hasAnyDefinitions()) {
+			list.add(library);
+		}
+	}
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,14 @@
             <scope>test</scope>
         </dependency>
 
+		<!-- Needed to be able to build using PowerMock on Java 8. See http://stackoverflow.com/a/33162314 -->
+		<dependency>
+			<groupId>org.javassist</groupId>
+			<artifactId>javassist</artifactId>
+			<version>3.19.0-GA</version>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- OpenMRS dependencies -->
 		<dependency>
 			<groupId>org.openmrs.api</groupId>


### PR DESCRIPTION
@mseaton I did initial work on this. So far I have only implemented support for "cohort", that supports the file extensions .reportingserializerxml and .sql.

I'll comment further on the ticket.