### PR TITLE
CB-46: Add patientWithAttribute to BuiltInCohortDefinitionLibrary

### DIFF
--- a/api/src/main/java/org/openmrs/module/reporting/cohort/definition/library/BuiltInCohortDefinitionLibrary.java
+++ b/api/src/main/java/org/openmrs/module/reporting/cohort/definition/library/BuiltInCohortDefinitionLibrary.java
@@ -15,11 +15,13 @@
 package org.openmrs.module.reporting.cohort.definition.library;
 
 import org.openmrs.EncounterType;
+import org.openmrs.PersonAttributeType;
 import org.openmrs.module.reporting.cohort.definition.AgeCohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.BirthAndDeathCohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.CohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.EncounterCohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.GenderCohortDefinition;
+import org.openmrs.module.reporting.cohort.definition.PersonAttributeCohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.MappedParametersCohortDefinition;
 import org.openmrs.module.reporting.definition.library.BaseDefinitionLibrary;
 import org.openmrs.module.reporting.definition.library.DocumentedDefinition;
@@ -124,5 +126,13 @@ public class BuiltInCohortDefinitionLibrary extends BaseDefinitionLibrary<Cohort
         cd.addParameter(new Parameter("diedOnOrAfter", "reporting.parameter.startDate", Date.class));
         cd.addParameter(new Parameter("diedOnOrBefore", "reporting.parameter.endDate", Date.class));
         return new MappedParametersCohortDefinition(cd, "diedOnOrAfter", "startDate", "diedOnOrBefore", "endDate");
+    }
+
+    @DocumentedDefinition("personWithAttribute")
+    public CohortDefinition getPersonWithAttribute() {
+        PersonAttributeCohortDefinition cd = new PersonAttributeCohortDefinition();
+        cd.addParameter(new Parameter("attributeType", "reporting.parameter.attributeType", PersonAttributeType.class));
+        cd.addParameter(new Parameter("values", "reporting.parameter.values", String.class, List.class, null));
+        return cd;
     }
 }

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -631,6 +631,8 @@ reporting.parameter.startDate=Start Date
 reporting.parameter.endDate=End Date
 reporting.parameter.location=Location
 reporting.parameter.locationList=Locations
+reporting.parameter.attributeType=Attribute Type
+reporting.parameter.values=List of values
 
 reporting.library.cohortDefinition.builtIn.males.name=Males
 reporting.library.cohortDefinition.builtIn.males.description=Patient gender is male
@@ -646,6 +648,8 @@ reporting.library.cohortDefinition.builtIn.anyEncounterDuringPeriod.name=Any enc
 reporting.library.cohortDefinition.builtIn.anyEncounterDuringPeriod.description=Patient has at least one encounter between {{startDate}} and {{endDate}}
 reporting.library.cohortDefinition.builtIn.anyEncounterOfTypesDuringPeriod.name=Any encounter of the given types during period
 reporting.library.cohortDefinition.builtIn.anyEncounterOfTypesDuringPeriod.description=Patient has at least one encounter of {{encounterTypes}} between {{startDate}} and {{endDate}}
+reporting.library.cohortDefinition.builtIn.personWithAttribute.name=Patients with certain attributes
+reporting.library.cohortDefinition.builtIn.personWithAttribute.description=Patients with {{attributeType}} equal to {{values}}
 
 reporting.library.patientDataDefinition.builtIn.patientId.name=Internal database patient ID
 reporting.library.patientDataDefinition.builtIn.patientId.description=patient.patientId from the database


### PR DESCRIPTION
[Link to the jira issue](https://issues.openmrs.org/browse/CB-46)
Add a new definition library key to the BuiltInChortDefinitionLibrary that makes use of the PersonAttributCohortDefinition. This will make it possible to be able to search for patients with certain attributes. The post made to the /reportingrest/adhocquery resource can then look like this
```
{
  "type": "org.openmrs.module.reporting.dataset.definition.PatientDataSetDefinition",
  "customRowFilterCombination": "1",
  "rowFilters": [
    {
      "type": "org.openmrs.module.reporting.cohort.definition.CohortDefinition",
      "key": "reporting.library.cohortDefinition.builtIn.patientWithAttribute",
      "parameterValues": {
      	"attributeType": "Mother's Name",
      	"values": ["Marvyn"]
      }
    }
  ]
}
```