### PR TITLE
REPORT-801: Add an anyEncounterDuringPeriodWithOccurrence to the BuiltInCohortDefinitionLibrary

### DIFF
--- a/api/src/main/java/org/openmrs/module/reporting/cohort/definition/library/BuiltInCohortDefinitionLibrary.java
+++ b/api/src/main/java/org/openmrs/module/reporting/cohort/definition/library/BuiltInCohortDefinitionLibrary.java
@@ -15,6 +15,8 @@
 package org.openmrs.module.reporting.cohort.definition.library;
 
 import org.openmrs.EncounterType;
+import org.openmrs.Location;
+import org.openmrs.Form;
 import org.openmrs.PersonAttributeType;
 import org.openmrs.module.reporting.cohort.definition.AgeCohortDefinition;
 import org.openmrs.module.reporting.cohort.definition.BirthAndDeathCohortDefinition;
@@ -85,7 +87,7 @@ public class BuiltInCohortDefinitionLibrary extends BaseDefinitionLibrary<Cohort
         cd.addParameter(new Parameter("minAge", "reporting.parameter.minAgeInYears", Integer.class));
         return cd;
     }
-    
+
     @DocumentedDefinition("ageRangeOnDate")
     public AgeCohortDefinition getAgeInRangeOnDate() {
         AgeCohortDefinition cd = new AgeCohortDefinition();
@@ -101,6 +103,19 @@ public class BuiltInCohortDefinitionLibrary extends BaseDefinitionLibrary<Cohort
         cd.addParameter(new Parameter("onOrAfter", "reporting.parameter.onOrAfter", Date.class));
         cd.addParameter(new Parameter("onOrBefore", "reporting.parameter.onOrBefore", Date.class));
         return new MappedParametersCohortDefinition(cd, "onOrAfter", "startDate", "onOrBefore", "endDate");
+    }
+
+    @DocumentedDefinition("encounterSearchAdvanced")
+    public CohortDefinition getAnyEncounterDuringPeriodWithOccurrence() {
+        EncounterCohortDefinition cd = new EncounterCohortDefinition();
+        cd.addParameter(new Parameter("onOrAfter", "reporting.parameter.startDate", Date.class));
+        cd.addParameter(new Parameter("onOrBefore", "reporting.parameter.endDate", Date.class));
+        cd.addParameter(new Parameter("atLeastCount", "reporting.parameter.atleast", Integer.class));
+        cd.addParameter(new Parameter("atMostCount", "reporting.parameter.atMost", Integer.class));
+        cd.addParameter(new Parameter("encounterTypeList", "reporting.parameter.encounterTypeList", EncounterType.class, List.class, null));
+        cd.addParameter(new Parameter("formList", "reporting.parameter.formList", Form.class, List.class, null));
+        cd.addParameter(new Parameter("locationList", "reporting.parameter.location", Location.class, List.class, null));
+        return new MappedParametersCohortDefinition(cd, "onOrAfter", "startDate", "onOrBefore", "endDate", "encounterTypeList", "encounterTypes", "locationList", "locations", "atLeastCount", "atLeast", "atMostCount", "atMost", "formList", "forms");
     }
 
     @DocumentedDefinition("anyEncounterOfTypesDuringPeriod")
@@ -119,7 +134,7 @@ public class BuiltInCohortDefinitionLibrary extends BaseDefinitionLibrary<Cohort
         cd.addParameter(new Parameter("bornOnOrBefore", "reporting.parameter.endDate", Date.class));
         return new MappedParametersCohortDefinition(cd, "bornOnOrAfter", "startDate", "bornOnOrBefore", "endDate");
     }
-    
+
     @DocumentedDefinition("diedDuringPeriod")
     public CohortDefinition getDiedDuringPeriod() {
         BirthAndDeathCohortDefinition cd = new BirthAndDeathCohortDefinition();

--- a/api/src/main/resources/messages.properties
+++ b/api/src/main/resources/messages.properties
@@ -1,9 +1,9 @@
-# Report Manager > Analysis Menu 
+# Report Manager > Analysis Menu
 reporting.run.title=Analysis & Reporting
 reporting.runReport.title=Run a Report
 reporting.dataSetViewer.title=Data Set Viewer
 
-# Report Manager 
+# Report Manager
 reporting.title=Reporting
 reporting.immediately=Immediately
 reporting.manage.title=Manage Report Definitions
@@ -25,7 +25,7 @@ reporting.saved=Saved
 reporting.type=Type
 reporting.label=Label
 
-# Report Manager > Administration Menu 
+# Report Manager > Administration Menu
 reporting.manageReports.title=Report Administration
 reporting.manageCohorts.title=Cohort Queries
 reporting.manageDataSets.title=Data Set Definitions
@@ -53,7 +53,7 @@ reporting.error.endDateBeforeStartDate=End date cannot be before Start date
 reporting.error.startDateInFuture=The Start date shouldn't be in the future
 reporting.error.endDateInFuture=The End date shouldn't be in the future
 
-# Report Manager > Error Messages 
+# Report Manager > Error Messages
 dao.error.title=Data Access Failure
 api.error.title=API Failure
 general.error.title=General Failure
@@ -110,8 +110,8 @@ reporting.columnModifier=Modifier
 reporting.columnModifier.any=Any
 reporting.columnModifier.first=First
 reporting.columnModifier.mostRecent=Most Recent
-reporting.columnModifier.firstNum=First 
-reporting.columnModifier.mostRecentNum=Most Recent 
+reporting.columnModifier.firstNum=First
+reporting.columnModifier.mostRecentNum=Most Recent
 reporting.columnValue=Value
 reporting.conceptExtras=Extras
 reporting.conceptExtra.obsDatetime=Obs Datetime
@@ -201,7 +201,7 @@ reporting.Report.schema.editXml=Edit Report XML Directly
 reporting.Report.manageSchema.title=Edit Report Schema
 reporting.Report.manageSchema.xml=Report Schema's XML representation
 reporting.Report.manageSchema.saved=Report Schema XML Saved Successfully
-reporting.Report.macros.title=Manage Report Macros 
+reporting.Report.macros.title=Manage Report Macros
 reporting.Report.cohortReport.enter=Create Cohort Report
 reporting.Report.cohortReport.edit=Edit Cohort Report
 reporting.Report.cohortReport.data=Report Data
@@ -330,16 +330,16 @@ reporting.EncounterCohortDefinition.which=Which encounters?
 reporting.EncounterCohortDefinition.timeQualifier=which ones
 reporting.EncounterCohortDefinition.locationList=at locations
 reporting.EncounterCohortDefinition.providerList=with providers
-reporting.EncounterCohortDefinition.encounterTypeList=of types 
+reporting.EncounterCohortDefinition.encounterTypeList=of types
 reporting.EncounterCohortDefinition.formList=from forms
 reporting.EncounterCohortDefinition.howMany=How many?
 reporting.EncounterCohortDefinition.atLeastCount=at least
 reporting.EncounterCohortDefinition.atMostCount=at most
 reporting.EncounterCohortDefinition.other=Other
-reporting.EncounterCohortDefinition.returnInverse=find patients who do NOT have matching encounters 
-reporting.EncounterCohortDefinition.createdBy=created by 
-reporting.EncounterCohortDefinition.createdOnOrAfter=created on or after 
-reporting.EncounterCohortDefinition.createdOnOrBefore=created on or before 
+reporting.EncounterCohortDefinition.returnInverse=find patients who do NOT have matching encounters
+reporting.EncounterCohortDefinition.createdBy=created by
+reporting.EncounterCohortDefinition.createdOnOrAfter=created on or after
+reporting.EncounterCohortDefinition.createdOnOrBefore=created on or before
 
 #====== InProgramCohortDefinition =====
 reporting.InProgramCohortDefinition=In Program Query
@@ -371,7 +371,7 @@ reporting.PatientIdentifierCohortDefinition.regexToMatch=Matching Regular Expres
 #====== PatientStateCohortDefinition =====
 reporting.PatientStateCohortDefinition=Patient State Query
 reporting.PatientStateCohortDefinition.statesGroup=Patients whose membership in one or more of the following
-reporting.PatientStateCohortDefinition.statesGroup.instructions=Include all patients who transitioned into one or more of the following states between [startedDate] and [endedDate].   
+reporting.PatientStateCohortDefinition.statesGroup.instructions=Include all patients who transitioned into one or more of the following states between [startedDate] and [endedDate].
 reporting.PatientStateCohortDefinition.states=States
 reporting.PatientStateCohortDefinition.startedDate=Started
 reporting.PatientStateCohortDefinition.startedOnOrAfter=On or after
@@ -400,7 +400,7 @@ reporting.BaseObsCohortDefinition.questionGroup=Question
 reporting.BaseObsCohortDefinition.timeModifier=which observation(s)
 reporting.BaseObsCohortDefinition.question=observations with this question
 reporting.BaseObsCohortDefinition.groupingConcept=only if in a group whose concept is
-reporting.BaseObsCohortDefinition.obsDatetimeGroup=When was it observed/measured? 
+reporting.BaseObsCohortDefinition.obsDatetimeGroup=When was it observed/measured?
 reporting.BaseObsCohortDefinition.onOrAfter=on or after
 reporting.BaseObsCohortDefinition.onOrBefore=on or before
 reporting.BaseObsCohortDefinition.otherGroup=Other
@@ -467,9 +467,9 @@ reporting.TextObsCohortDefinition.valueList=values
 reporting.PersonAttributeCohortDefinition=Person Attribute Query
 reporting.PersonAttributeCohortDefinition.instructions=
 reporting.PersonAttributeCohortDefinition.attributeType=Attribute Type should equal
-reporting.PersonAttributeCohortDefinition.values=Attribute Values should include 
-reporting.PersonAttributeCohortDefinition.valueConcepts=Concept Attribute Values should include 
-reporting.PersonAttributeCohortDefinition.valueLocations=Location Attribute Values should include 
+reporting.PersonAttributeCohortDefinition.values=Attribute Values should include
+reporting.PersonAttributeCohortDefinition.valueConcepts=Concept Attribute Values should include
+reporting.PersonAttributeCohortDefinition.valueLocations=Location Attribute Values should include
 reporting.PersonAttributeCohortDefinition.attributeTypeGroup=Attribute Type
 reporting.PersonAttributeCohortDefinition.attributeTypeGroup.instructions=Include patients with attributes that match the selected [Attribute Type].
 reporting.PersonAttributeCohortDefinition.attributeValuesGroup=Attribute Values
@@ -488,7 +488,7 @@ reporting.ObsActiveListPersonDataDefinition=Obs-based Active List
 reporting.ObsForPersonDataDefinition=Obs
 reporting.ObsForPersonDataDefinition.whichEncounter=Which encounters?
 reporting.ObsForPersonDataDefinition.which=Which
-reporting.ObsForPersonDataDefinition.encounterTypeList=of types 
+reporting.ObsForPersonDataDefinition.encounterTypeList=of types
 reporting.ObsForPersonDataDefinition.formList=from forms
 reporting.PersonAttributeDataDefinition=Person Attribute
 reporting.PersonIdDataDefinition=Person ID
@@ -594,7 +594,7 @@ reporting.ExcelReportRenderer.expressions.description=To identify values that ca
 reporting.ExcelReportRenderer.expressions.prefix=Prefix
 reporting.ExcelReportRenderer.expressions.suffix=Suffix
 reporting.ExcelReportRenderer.resourceFile=Excel Template
-reporting.ExcelReportRenderer.resourceFile.description=A custom .xls template that will be used to renderer the report.  
+reporting.ExcelReportRenderer.resourceFile.description=A custom .xls template that will be used to renderer the report.
 reporting.ExcelReportRenderer.repeatingSections=Repeating sections
 reporting.ExcelReportRenderer.repeatingSections.description=To show multiple rows on the final excel spreadsheet.
 reporting.ExcelReportRenderer.repeatingSections.sheet=Sheet
@@ -633,6 +633,9 @@ reporting.parameter.location=Location
 reporting.parameter.locationList=Locations
 reporting.parameter.attributeType=Attribute Type
 reporting.parameter.values=List of values
+reporting.parameter.formList=Forms
+reporting.parameter.atLeastCount=Minimum Occurence
+reporting.parameter.atMostCount=Maximum Occurence
 
 reporting.library.cohortDefinition.builtIn.males.name=Males
 reporting.library.cohortDefinition.builtIn.males.description=Patient gender is male


### PR DESCRIPTION
Details: Add an `anyEncounterDuringPeriodWithOccurrence` definition to the `BuiltInChortDefinitionLibrary` that makes it possible to search for patients' encounter based on the type, location, start date and end date in the encounter tab of the cohort builder. Resource should look like this
`{
"type": "org.openmrs.module.reporting.dataset.definition.PatientDataSetDefinition",
"columns": [
{ "type": "org.openmrs.module.reporting.data.patient.definition.PatientDataDefinition", "name": "Given Name", "key": "reporting.library.patientDataDefinition.builtIn.preferredName.givenName" }
,
{ "type": "org.openmrs.module.reporting.data.patient.definition.PatientDataDefinition", "name": "Family Name", "key": "reporting.library.patientDataDefinition.builtIn.preferredName.familyName" }
],
"customRowFilterCombination": "1",
"rowFilters": [
{
"type": "org.openmrs.module.reporting.cohort.definition.CohortDefinition",
"key": "reporting.library.cohortDefinition.builtIn.anyEncounterDuringPeriodWithOccurrence",
"parameterValues":
{ "encounterType": ["ADULTINITIAL"], "location": ["Inpatient Ward"], "atLeast": 2, "form": ["AMPATH Adult Initial Visit Form"] }
}
]
}`