### PR TITLE
Add support of Obs lists as input of ObsValueConverter

### DIFF
--- a/api-tests/src/test/java/org/openmrs/module/reporting/data/converter/ObsValueConverterTest.java
+++ b/api-tests/src/test/java/org/openmrs/module/reporting/data/converter/ObsValueConverterTest.java
@@ -1,0 +1,55 @@
+package org.openmrs.module.reporting.data.converter;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.openmrs.Obs;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.ObsService;
+import org.openmrs.test.BaseModuleContextSensitiveTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+
+public class ObsValueConverterTest extends BaseModuleContextSensitiveTest {
+
+    @Autowired
+    @Qualifier("conceptService")
+    private ConceptService conceptService;
+    
+    @Autowired
+    @Qualifier("obsService")
+    private ObsService obsService;
+
+    @Test
+    public void shouldHandleListOfObs() {
+
+    	ObsValueConverter converter = new ObsValueConverter();
+    	
+    	List<Obs> obses = new ArrayList<Obs>();
+    	obses.add(obsService.getObs(11));
+    	obses.add(obsService.getObs(12));
+    	obses.add(obsService.getObs(13));
+    	
+    	List<Object> results = ((List) converter.convert(obses));
+    	
+    	assertEquals(3, results.size());
+
+    	assertEquals(new Double(175.0), (Double) results.get(0));
+    	assertEquals("PB and J", (String) results.get(1));
+    	assertEquals(true, (Boolean) results.get(2));
+    	
+    }
+    
+    @Test
+    public void shouldHandleNullInput() {
+    	
+    	ObsValueConverter converter = new ObsValueConverter();
+    	assertNull(converter.convert(null));
+    	assertNull(converter.convert(new Object()));
+    }
+
+
+}

--- a/api/src/main/java/org/openmrs/module/reporting/data/converter/ObsValueConverter.java
+++ b/api/src/main/java/org/openmrs/module/reporting/data/converter/ObsValueConverter.java
@@ -1,22 +1,39 @@
 package org.openmrs.module.reporting.data.converter;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.openmrs.Obs;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.reporting.common.ObjectUtil;
 
 /**
- * Converts an Obs to it's value
+ * Converts an Obs to its value
  */
 public class ObsValueConverter implements DataConverter {
 
-    public ObsValueConverter() { }
+	public ObsValueConverter() { }
 
-    @Override
-    public Object convert(Object original) {
-		Obs o = (Obs) original;
-		if (o == null) {
+	@Override
+	public Object convert(Object original) {
+
+		if (original == null) {
 			return null;
 		}
+		if (original instanceof Obs) {
+			Obs o = (Obs) original;
+			return getObsValue(o);
+		} else if (original instanceof List) {
+			List<Object> obsValues = new ArrayList<Object>();
+			for (Obs o : ((List<Obs>) original) ) {
+				obsValues.add(getObsValue(o));
+			}
+			return obsValues;
+		} 
+		return original;
+	}
+
+	private Object getObsValue(Obs o) {
 		if (o.getValueBoolean() != null) {
 			return o.getValueBoolean();
 		}
@@ -45,15 +62,15 @@ public class ObsValueConverter implements DataConverter {
 			return o.getValueTime();
 		}
 		return o.getValueAsString(Context.getLocale());
-    }
+	}
 
-    @Override
-    public Class<?> getInputDataType() {
-        return Obs.class;
-    }
+	@Override
+	public Class<?> getInputDataType() {
+		return Object.class;
+	}
 
-    @Override
-    public Class<?> getDataType() {
-        return Object.class;
-    }
+	@Override
+	public Class<?> getDataType() {
+		return Object.class;
+	}
 }


### PR DESCRIPTION
Currently the **ObsValueConverter** only handles single obs.
Adding the ability to convert more than one obs.