### PR TITLE
REPORT-714 : added a handler for CohortIndicators

### DIFF
--- a/omod/src/main/java/org/openmrs/module/reporting/web/widget/handler/CohortIndicatorHandler.java
+++ b/omod/src/main/java/org/openmrs/module/reporting/web/widget/handler/CohortIndicatorHandler.java
@@ -1,0 +1,44 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+package org.openmrs.module.reporting.web.widget.handler;
+
+import java.util.List;
+
+import org.openmrs.annotation.Handler;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.htmlwidgets.web.WidgetConfig;
+import org.openmrs.module.htmlwidgets.web.html.CodedWidget;
+import org.openmrs.module.htmlwidgets.web.html.Option;
+import org.openmrs.module.reporting.indicator.CohortIndicator;
+import org.openmrs.module.reporting.indicator.Indicator;
+import org.openmrs.module.reporting.indicator.service.IndicatorService;
+
+@Handler(supports = { CohortIndicator.class }, order = 25)
+public class CohortIndicatorHandler extends IndicatorHandler {
+	
+	/**
+	 * @see IndicatorHandler#populateOptions(WidgetConfig, CodedWidget)
+	 */
+	@Override
+	public void populateOptions(WidgetConfig config, CodedWidget widget) {
+		List<Indicator> listOfAllIndicators = null;
+		String tag = config.getAttributeValue("tag", null);
+		if (tag != null) {
+			listOfAllIndicators = Context.getService(IndicatorService.class).getDefinitionsByTag(tag);
+		} else {
+			listOfAllIndicators = Context.getService(IndicatorService.class).getAllDefinitions(false);
+		}
+		for (Indicator indicator : listOfAllIndicators) {
+			if (indicator instanceof CohortIndicator) {
+				widget.addOption(new Option(indicator.getUuid(), indicator.getName(), null, indicator), config);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Ticket URL : https://issues.openmrs.org/browse/REPORT-714
# Problem
The handler for the cohort indicators was retrieving a list of the generic indicator class. Then if the user created a SQL Indicator and tried to select it they would get an exception when CohortIndicatorAndDimensionSpecificationPortletController.java would try to cast it back to a CohortIndicator.

![report-714-before](https://user-images.githubusercontent.com/932966/37577845-ebd7ba26-2b0a-11e8-8def-377252770667.png)
![report-714-error](https://user-images.githubusercontent.com/932966/37577846-ef7012a0-2b0a-11e8-9da7-d5620ba2bf81.png)

# Solution
This handler can be used in the JSP file by pointing specifically at a CohortIndicator class. The old generic handler can still be used by pointing to the more generic class.

![report-714-after](https://user-images.githubusercontent.com/932966/37577857-f909a4fc-2b0a-11e8-8217-692e28a40564.png)
