### PR TITLE
REPORT-868:Add Testing Profiles to test against core 2.3 and 2.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -372,6 +372,15 @@
                 <reportingApiConditionalArtifactId>reporting-api-2.0</reportingApiConditionalArtifactId>
             </properties>
         </profile>
+          <profile>
+            <id>2.4</id>
+            <properties>
+                <openMRSVersion>2.4.0</openMRSVersion>
+                <openMRSMinorVersion>2.4</openMRSMinorVersion>
+                <jacksonVersion>1.9.13</jacksonVersion>
+                <reportingApiConditionalArtifactId>reporting-api-2.4</reportingApiConditionalArtifactId>
+            </properties>
+        </profile>
 	</profiles>
 
 	<build>


### PR DESCRIPTION
https://issues.openmrs.org/browse/REPORT-868

WIP Am considering this as a beginning point and spear head this. Am accounting error when i add profilers of core 2.3 so i have first used the one of 2.4 and i think we need to create another submodule for reporting module 2.3 in order to depend on core 2.3 

 Again if we are to depend on 2.3 or 2.4, we can first consider upgrading reporting module to depend on 2.3 version in the separate ticket and depend on it. More guidance about my suggestion will be higly appreciated thanks
 cc @dkayiwa , @mogoodrich @ibacher 