### PR TITLE
REPORT-909 Fix report renderer paths for editing report designs

### DIFF
--- a/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/DelimitedTextReportRendererFormController.java
+++ b/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/DelimitedTextReportRendererFormController.java
@@ -47,7 +47,7 @@ public class DelimitedTextReportRendererFormController {
 	/**
 	 *  prepares a new form for the a DelimitedReportRenderer
 	 */
-	@RequestMapping("/module/reporting/reports/renderers/delimitedTextReportRenderer")
+	@RequestMapping("/module/reporting/reports/renderers/delimitedTextReportRenderer.form")
 	public void delimitedTextReportRenderer(ModelMap model, 
 								@RequestParam(required=false, value="reportDesignUuid") String reportDesignUuid, 
 								@RequestParam(required=false, value="reportDefinitionUuid") String reportDefinitionUuid,
@@ -95,7 +95,7 @@ public class DelimitedTextReportRendererFormController {
 	 * @throws IllegalAccessException 
 	 * @throws InstantiationException 
 	 */
-	@RequestMapping("/module/reporting/reports/renderers/saveDelimitedTextReportDesign")
+	@RequestMapping("/module/reporting/reports/renderers/saveDelimitedTextReportDesign.form")
 	public String saveDelimitedTextReportDesign(ModelMap model, HttpServletRequest request,
 					@RequestParam(required=false, value="uuid") String uuid,
 					@RequestParam(required=true,  value="name") String name,

--- a/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/ExcelReportRendererFormController.java
+++ b/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/ExcelReportRendererFormController.java
@@ -57,7 +57,7 @@ public class ExcelReportRendererFormController {
 	/**
 	 *  prepares a new form for the Excel report renderers
 	 */
-	@RequestMapping("/module/reporting/reports/renderers/excelReportRenderer")
+	@RequestMapping("/module/reporting/reports/renderers/excelReportRenderer.form")
 	public void excelReportRenderer(ModelMap model, 
 								@RequestParam(required=false, value="reportDesignUuid") String reportDesignUuid, 
 								@RequestParam(required=false, value="reportDefinitionUuid") String reportDefinitionUuid,
@@ -110,7 +110,7 @@ public class ExcelReportRendererFormController {
 	 * @throws InstantiationException 
 	 */
 	@SuppressWarnings("unchecked")
-	@RequestMapping("/module/reporting/reports/renderers/saveExcelReportRenderer")
+	@RequestMapping("/module/reporting/reports/renderers/saveExcelReportRenderer.form")
 	public String saveExcelReportRenderer(ModelMap model, HttpServletRequest request,
 					@RequestParam(required=false, value="uuid") String uuid,
 					@RequestParam(required=true,  value="name") String name,

--- a/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/NonConfigurableReportRendererFormController.java
+++ b/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/NonConfigurableReportRendererFormController.java
@@ -42,7 +42,7 @@ public class NonConfigurableReportRendererFormController {
 	/**
 	 *  prepares a new form for the a IndicatorReportRenderer
 	 */
-	@RequestMapping("/module/reporting/reports/renderers/nonConfigurableReportRenderer")
+	@RequestMapping("/module/reporting/reports/renderers/nonConfigurableReportRenderer.form")
 	public void nonConfigurableReportRenderer(ModelMap model, 
 								@RequestParam(required=false, value="reportDesignUuid") String reportDesignUuid, 
 								@RequestParam(required=false, value="reportDefinitionUuid") String reportDefinitionUuid,
@@ -78,7 +78,7 @@ public class NonConfigurableReportRendererFormController {
 	/**
 	 * Saves report design
 	 */
-	@RequestMapping("/module/reporting/reports/renderers/saveNonConfigurableReportRenderer")
+	@RequestMapping("/module/reporting/reports/renderers/saveNonConfigurableReportRenderer.form")
 	public String saveNonConfigurableReportRenderer(ModelMap model, HttpServletRequest request,
 					@RequestParam(required=false, value="uuid") String uuid,
 					@RequestParam(required=true,  value="name") String name,

--- a/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/TextTemplateFormController.java
+++ b/omod/src/main/java/org/openmrs/module/reporting/web/reports/renderers/TextTemplateFormController.java
@@ -79,7 +79,7 @@ public class TextTemplateFormController {
 	 *  prepares a new form for the a TextTemplateRenderer
 	 * @throws UnsupportedEncodingException 
 	 */
-	@RequestMapping("/module/reporting/reports/renderers/textTemplateReportRenderer")
+	@RequestMapping("/module/reporting/reports/renderers/textTemplateReportRenderer.form")
 	public void textTemplateReportRenderer(ModelMap model, 
 								@RequestParam(required=false, value="reportDesignUuid") String reportDesignUuid, 
 								@RequestParam(required=false, value="reportDefinitionUuid") String reportDefinitionUuid,
@@ -124,7 +124,7 @@ public class TextTemplateFormController {
 	 * Saves report design
 	 * @throws UnsupportedEncodingException 
 	 */
-	@RequestMapping("/module/reporting/reports/renderers/saveTextTemplateReportRendererDesign")
+	@RequestMapping("/module/reporting/reports/renderers/saveTextTemplateReportRendererDesign.form")
 	public String saveTextTemplateReportRendererDesign(ModelMap model, HttpServletRequest request,
 					@RequestParam(required=false, value="uuid") String uuid,
 					@RequestParam(required=true,  value="name") String name,
@@ -203,7 +203,7 @@ public class TextTemplateFormController {
 		return userParams;
 	}
 	
-	@RequestMapping( value="/module/reporting/reports/renderers/previewTextTemplateReportRenderer", method=RequestMethod.GET)
+	@RequestMapping( value="/module/reporting/reports/renderers/previewTextTemplateReportRenderer.form", method=RequestMethod.GET)
 	public void initPreviewForm(ModelMap model, HttpServletRequest request,
 			@RequestParam(required=true, value="reportDefinition") String reportDefinitionUuid,
 			@RequestParam(required=false, value="uuid") String uuid,
@@ -257,7 +257,7 @@ public class TextTemplateFormController {
 	}
 		
 	@SuppressWarnings("unchecked")
-	@RequestMapping(value="/module/reporting/reports/renderers/previewTextTemplateReportRenderer", method=RequestMethod.POST)
+	@RequestMapping(value="/module/reporting/reports/renderers/previewTextTemplateReportRenderer.form", method=RequestMethod.POST)
 	public void previewScript(ModelMap model, HttpServletRequest request,
 			@RequestParam(required=true, value="reportDefinition") String reportDefinitionUuid,
 			@RequestParam(required=true, value="uuid") String uuid,


### PR DESCRIPTION
Fixes 404 Not Found response when attempting to add or edit a new Report Design.

Similar to changes made in commit 237d85c05730fed7c4d3d50ab27e962aeec6f446