### PR TITLE
Support build on maven3 with Java 8

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,6 +18,12 @@
 			<version>${reportingCompatibilityVersion}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>javax.activation-api</artifactId>
+			<version>1.2.0</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 	
 </project>

--- a/api/src/main/java/org/openmrs/module/reporting/report/processor/EmailReportProcessor.java
+++ b/api/src/main/java/org/openmrs/module/reporting/report/processor/EmailReportProcessor.java
@@ -23,7 +23,6 @@ import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMessage.RecipientType;
 import javax.mail.internet.MimeMultipart;
 
 import org.apache.commons.lang.StringUtils;
@@ -103,7 +102,7 @@ public class EmailReportProcessor implements ReportProcessor {
 			
 			m.setFrom(new InternetAddress(configuration.getProperty("from")));
 			for (String recipient : configuration.getProperty("to", "").split("\\,")) {
-				m.addRecipient(RecipientType.TO, new InternetAddress(recipient));
+				m.addRecipient(Message.RecipientType.TO, new InternetAddress(recipient));
 			}
 	
 			// TODO: Make these such that they can contain report information

--- a/pom.xml
+++ b/pom.xml
@@ -447,7 +447,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
-				<version>1.7</version>
+				<version>3.6.0</version>
 				<executions>
 					<execution>
 						<phase>generate-test-resources</phase>
@@ -469,8 +469,8 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
 					<configuration>
-						<target>1.6</target>
-						<source>1.6</source>
+						<target>1.8</target>
+						<source>1.8</source>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
Changes I had to make to build this project in my dev environment using maven3 (3.9.2) with Java 8.

Essential change in file pom.xml, setting `maven-compiler-plugin` source and target to 1.8 to resolve compiler failure with "Source option 6 is no longer supported. Use 7 or later."

Changes to api/pom.xml to resolve missing dependency.

Changes to EmailReportProcessor.java to resolve a compiler error.