### PR TITLE
REPORT-907: CLONE - Create an HttpReportProcessor

### DIFF
--- a/api/src/main/java/org/openmrs/module/reporting/config/ReportLoader.java
+++ b/api/src/main/java/org/openmrs/module/reporting/config/ReportLoader.java
@@ -28,6 +28,7 @@ import org.openmrs.module.reporting.report.definition.service.ReportDefinitionSe
 import org.openmrs.module.reporting.report.processor.DiskReportProcessor;
 import org.openmrs.module.reporting.report.processor.EmailReportProcessor;
 import org.openmrs.module.reporting.report.processor.LoggingReportProcessor;
+import org.openmrs.module.reporting.report.processor.HttpReportProcessor;
 import org.openmrs.module.reporting.report.renderer.CsvReportRenderer;
 import org.openmrs.module.reporting.report.renderer.ReportDesignRenderer;
 import org.openmrs.module.reporting.report.renderer.XlsReportRenderer;
@@ -287,6 +288,9 @@ public class ReportLoader {
                     }
                     else if ("logging".equalsIgnoreCase(type)) {
                         type = LoggingReportProcessor.class.getName();
+                    }
+                    else if ("http".equalsIgnoreCase(type)) {
+                        type = HttpReportProcessor.class.getName();
                     }
                     c.setProcessorType(type);
                     c.setRunOnSuccess(processorDescriptor.getRunOnSuccess());

--- a/api/src/main/java/org/openmrs/module/reporting/report/processor/HttpReportProcessor.java
+++ b/api/src/main/java/org/openmrs/module/reporting/report/processor/HttpReportProcessor.java
@@ -1,0 +1,108 @@
+/**
+ * This Source Code Form is subject to the terms of the Mozilla Public License,
+ * v. 2.0. If a copy of the MPL was not distributed with this file, You can
+ * obtain one at http://mozilla.org/MPL/2.0/. OpenMRS is also distributed under
+ * the terms of the Healthcare Disclaimer located at http://openmrs.org/license.
+ *
+ * Copyright (C) OpenMRS Inc. OpenMRS is a registered trademark and the OpenMRS
+ * graphic logo is a trademark of OpenMRS Inc.
+ */
+
+package org.openmrs.module.reporting.report.processor;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.module.reporting.report.Report;
+import org.springframework.stereotype.Component;
+
+/**
+ * A ReportProcessor which sends the rendered report via POST
+*/
+@Component
+public class HttpReportProcessor implements ReportProcessor {
+
+    protected Log log = LogFactory.getLog(this.getClass());
+
+    public final String CONNECTION_URL = "url";
+    public final String SUBJECT = "subject";
+    public final String ADD_REPORT = "addReport";
+
+    /**
+     * @see ReportProcessor#getConfigurationPropertyNames()
+    */
+
+    @Override
+    public List<String> getConfigurationPropertyNames() {
+
+        List<String> ret = new ArrayList<String>();
+        ret.add(CONNECTION_URL);
+        ret.add(SUBJECT);
+        ret.add(ADD_REPORT);
+        return ret;
+    }
+
+    /**
+     * Performs some action on the given report
+    * @param report the Report to process
+    */
+
+    @Override
+    public void process(Report report, Properties configuration) {
+        // TODO Auto-generated method stub
+        HttpURLConnection connection = null;
+        try {
+            if (report.getRenderedOutput() != null && "true".equalsIgnoreCase(configuration.getProperty(SUBJECT))) {
+
+                URL url = new URL(configuration.getProperty(CONNECTION_URL));
+
+                connection = (HttpURLConnection) url.openConnection();
+                
+                connection.setRequestMethod("POST");
+
+                connection.setRequestProperty("Content-Type", "application/json");
+
+                connection.setDoOutput(true);
+
+                String reportData = configuration.getProperty(ADD_REPORT, "");
+                reportData += new String(report.getRenderedOutput());
+
+                DataOutputStream outputStream = new DataOutputStream(connection.getOutputStream());
+                outputStream.writeBytes(reportData);
+                outputStream.flush();
+                outputStream.close();
+
+                int responseCode = connection.getResponseCode();
+                if (responseCode == HttpURLConnection.HTTP_OK) {
+
+                    BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+                    String responseData;
+                    while ((responseData = reader.readLine()) != null) {
+                        System.out.println(responseData);
+                    }
+                    reader.close();
+                } else {
+                    System.out.println("HTTP POST request failed with response code: " + responseCode);
+                }
+
+            }
+
+        } catch(IOException e) {
+            throw new RuntimeException("Error occured while sending report via HTTP POST", e);
+        } finally {
+            if(connection != null) {
+                connection.disconnect();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Issue: REPORT 907

This PR introduces a new HttpReportProcessor within the OpenMRS Reporting module, enabling the sending of reports to a designated URL via an HTTP POST request. The processor allows for configuration of the HTTP URL and other settings through a properties configuration file, providing flexibility and customization options for report delivery.