### PR TITLE
REPORT-908 Unescape XML before deserializing column definition

### DIFF
--- a/omod/src/main/java/org/openmrs/module/reporting/web/datasets/PatientDataSetEditor.java
+++ b/omod/src/main/java/org/openmrs/module/reporting/web/datasets/PatientDataSetEditor.java
@@ -19,6 +19,7 @@ import java.util.Properties;
 import javax.servlet.http.HttpSession;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.openmrs.api.context.Context;
@@ -193,7 +194,7 @@ public class PatientDataSetEditor {
     	}
 		
 		MappedEditor editor = new MappedEditor();
-		editor.setAsText(columnDefinition);
+		editor.setAsText(StringEscapeUtils.unescapeXml(columnDefinition));
 		Mapped<DataDefinition> mappedDef = (Mapped<DataDefinition>) editor.getValue();
 		
     	dsd.addColumn(label, mappedDef.getParameterizable(), mappedDef.getParameterMappings());


### PR DESCRIPTION
[REPORT-908](https://openmrs.atlassian.net/browse/REPORT-908)

Previously, any attempt to add a column to a row-per-patient report dataset resulted in a SerializationException e.g.
```
org.openmrs.serialization.SerializationException: An error occurred during deserialization of data <&lt;org.openmrs.module.reporting.evaluation.parameter.Mapped id="1"&gt;
  &lt;parameterizable class="org.openmrs.module.reporting.data.person.definition.PersonAttributeDataDefinition" id="2" uuid="e9d48622-6bb0-44cb-a283-93161e6102c9"/&gt;
  &lt;parameterMappings class="linked-hash-map" id="3"/&gt;
&lt;/org.openmrs.module.reporting.evaluation.parameter.Mapped&gt;>
```

Adding code to unescape the XML for the column definition before deserialization resolves the problem. I was now able to add various columns to the report when using module Serialization XStream v0.2.16 (as per the reference distro)



[REPORT-908]: https://openmrs.atlassian.net/browse/REPORT-908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ