### PR TITLE
TRUNK-6566: Migrate Reporting Module to Codecov with Java 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,12 +8,16 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+permissions:
+    contents: read
+    id-token: write
+
 jobs:
   build:
     strategy:
       matrix:
         platform: [ ubuntu-latest ]
-        java-version: [ 8, 11, 17, 21, 24 ]
+        java-version: [ 8, 11, 17, 21, 24, 25]
 
     runs-on: ${{ matrix.platform }}
     env:
@@ -36,4 +40,11 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Build with Maven
         run: mvn clean install --batch-mode --show-version --file pom.xml
+
+      - name: Upload coverage to Codecov
+        if: ${{ matrix.java-version == '25' && matrix.platform == 'ubuntu-lastest'  }}
+        uses: codecov/codecov-action@v5
+        continue-on-error: true
+        with:
+            use_oidc: true
 


### PR DESCRIPTION
I noticed the Core was migrated to Codecov (TRUNK-6566). I have applied the same changes to the Reporting Module, including OIDC authentication and Java 25 support. Verified passing builds in my fork.